### PR TITLE
Fix wrong header date

### DIFF
--- a/tennisblock_client/src/components/ui/Breadcrumb/index.js
+++ b/tennisblock_client/src/components/ui/Breadcrumb/index.js
@@ -11,7 +11,6 @@ const matchRoute = (pathname) => {
 class Breadcrumb extends Component {
   render() {
     const match = matchRoute(this.props.history.location.pathname)
-    console.log('breadcrumb', match)
     return (
       <nav>
         <ol className="breadcrumb">

--- a/tennisblock_client/src/components/ui/Header/Date/index.js
+++ b/tennisblock_client/src/components/ui/Header/Date/index.js
@@ -10,8 +10,7 @@ const headerDate = ({ link, date, classNames }) => (
         &nbsp;
         {new Date(date).getFullYear()}
         &nbsp;| &nbsp;
-        {new Date(date).toLocaleString('en-us', { month: "long" })}&nbsp;
-        {new Date(date).getDate()}
+        {new Date(date).toLocaleString('en-us', { month: "long", day: "2-digit" })}
     </Link>
   </h2>
 )


### PR DESCRIPTION
The header date in my local is fine so I'm not sure if also does for you but I see the code for getting the day not uses timezone so maybe thats the cause and this is the fix.